### PR TITLE
OutputMetadata conforms to Buildpack Staging Response protocol

### DIFF
--- a/Builder/OutputMetadata.cs
+++ b/Builder/OutputMetadata.cs
@@ -16,11 +16,11 @@ namespace Builder
             get { return JsonConvert.SerializeObject(ExecutionMetadata); }
         }
 
-        [JsonProperty("detected_start_command")]
-        public DetectedStartCommand DetectedStartCommand {
+        [JsonProperty("process_types")]
+        public ProcessTypes ProcessTypes {
             get
             {
-                return new DetectedStartCommand()
+                return new ProcessTypes()
                 {
                     Web =
                         (ExecutionMetadata.StartCommand + " " + String.Join(" ", ExecutionMetadata.StartCommandArgs))
@@ -28,9 +28,15 @@ namespace Builder
                 };
             }
         }
+
+        [JsonProperty("lifecycle_metadata")]
+        public string LifecycleMetadata{ 
+        {
+            get { return new LifecycleMetadata() }
+        }
     }
 
-    public class DetectedStartCommand
+    public class ProcessTypes 
     {
         [JsonProperty("web")]
         public string Web { get; set; }
@@ -56,6 +62,27 @@ namespace Builder
         {
             get;
             set;
+        }
+    }
+
+    public class LifecycleMetadata 
+    {
+        public LifecycleMetadata()
+        {
+            DetectedBuildpack = "windows";
+            BuildpackKey = ""; 
+        }
+
+        [JsonProperty("detected_buildpack")]
+        public string DetectedBuildpack 
+        {
+            get;
+        }
+
+        [JsonProperty("buildpack_key")]
+        public string BuildpackKey
+        {
+            get;
         }
     }
 }


### PR DESCRIPTION
This change reflects the new stardardized protocol for staging response
messages. The new wire protocol is as follows:

``` json
{
  "process_types": {
    "web": "start command"
  },
  "execution_metadata": "only the launcher cares about this now",
  "lifecycle_metadata": {
    "detected_buildpack": "windows",
    "buildpack_key": ""
  }
}
```

Fair warning, we whipped this up in vim so it is only a partial change, we just wanted to demonstrate the new format. This commit will probably break tests, and should be vetted before merging.

If you don't want this pr, and would prefer to make the change yourself, we're fine with that.
- @tedsuo  & @zrob
