### PR TITLE
[HCFRO-85] Modify healthcheck to verify TCP port by default

### DIFF
--- a/Healthcheck.Tests/Features/HealthcheckSpec.cs
+++ b/Healthcheck.Tests/Features/HealthcheckSpec.cs
@@ -1,10 +1,10 @@
-﻿using System.Text;
-using NSpec;
+﻿using NSpec;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 
 namespace Healthcheck.Tests.Specs
@@ -14,20 +14,28 @@ namespace Healthcheck.Tests.Specs
         public void describe_()
         {
             int externalPort = -1;
-            before = () => externalPort = GetFreeTcpPort();
             Process process = null;
             string processOutputData = null;
             string processErrorData = null;
+            string arguments = "";
+
+            before = () =>
+            {
+                externalPort = GetFreeTcpPort();
+                arguments = "";
+            };
 
             act = () =>
             {
+                arguments += "-port=8080 ";
+
                 var workingDir = Path.GetFullPath(Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().CodeBase, "..", "..", "..", "..", "Healthcheck", "bin").Replace("file:///", ""));
                 process = new Process
                 {
                     StartInfo =
                     {
                         FileName = Path.Combine(workingDir, "Healthcheck.exe"),
-                        Arguments = "-port=8080",
+                        Arguments = arguments,
                         WorkingDirectory = workingDir,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
@@ -45,11 +53,15 @@ namespace Healthcheck.Tests.Specs
                 process.WaitForExit();
             };
 
-            describe["when the server is returning non success status code"] = () =>
+            describe["when the HTTP server is returning non success status code"] = () =>
             {
                 HttpListener httpListener = null;
                 var stacktrace = "BOOOOOOM";
-                before = () => httpListener = startServer("*", externalPort, 500, stacktrace);
+                before = () =>
+                {
+                    arguments += "-uri=/ ";
+                    httpListener = startHttpServer("*", externalPort, 500, stacktrace);
+                };
                 after = () => httpListener.Stop();
 
                 it["exits 1 and logs the stack trace"] = () =>
@@ -60,10 +72,34 @@ namespace Healthcheck.Tests.Specs
                 };
             };
 
-            describe["when the address is listening"] = () =>
+            describe["when the HTTP server is timing out"] = () =>
             {
                 HttpListener httpListener = null;
-                before = () => httpListener = startServer("*", externalPort);
+
+                before = () =>
+                {
+                    arguments += "-uri=/ ";
+                    arguments += "-timeout=100ms ";
+                    httpListener = startHttpServer("*", externalPort, 200, "ok", TimeSpan.FromMilliseconds(500));
+                };
+                after = () => httpListener.Stop();
+
+                it["exits 1 and logs the stack trace"] = () =>
+                {
+                    processOutputData.should_contain("healthcheck failed");
+                    processOutputData.should_contain("waiting for process to start up");
+                    process.ExitCode.should_be(1);
+                };
+            };
+
+            describe["when the HTTP server is returning a success status code"] = () =>
+            {
+                HttpListener httpListener = null;
+                before = () =>
+                {
+                    arguments += "-uri=/ ";
+                    httpListener = startHttpServer("*", externalPort);
+                };
                 after = () => httpListener.Stop();
 
                 it["exits 0 and logs it succeeded"] = () =>
@@ -73,11 +109,52 @@ namespace Healthcheck.Tests.Specs
                 };
             };
 
-            describe["when the address is not listening"] = () =>
+            describe["when the address is not listening and using TCP check"] = () =>
             {
                 it["exits 1 and logs it failed"] = () =>
                 {
                     processOutputData.should_contain("healthcheck failed\r\n");
+                    process.ExitCode.should_be(1);
+                };
+            };
+
+            describe["when the address is not listening and using HTTP check"] = () =>
+            {
+                before = () =>
+                {
+                    arguments += "-uri=/ ";
+                };
+
+                it["exits 1 and logs it failed"] = () =>
+                {
+                    processOutputData.should_contain("healthcheck failed\r\n");
+                    process.ExitCode.should_be(1);
+                };
+            };
+
+            describe["when the TCP server is listening"] = () =>
+            {
+                TcpListener tcpListener = null;
+                before = () => tcpListener = startTcpServer(IPAddress.Any, externalPort);
+                after = () => tcpListener.Stop();
+
+                it["exits 0 and logs it succeeded"] = () =>
+                {
+                    processOutputData.should_contain("healthcheck passed\r\n");
+                    process.ExitCode.should_be(0);
+                };
+            };
+
+            describe["when the network argument is invalid"] = () =>
+            {
+                before = () =>
+                {
+                    arguments += "-network=unix ";
+                };
+
+                it["exits 1 and logs it failed"] = () =>
+                {
+                    processOutputData.should_contain("'unix' not supported");
                     process.ExitCode.should_be(1);
                 };
             };
@@ -94,7 +171,7 @@ namespace Healthcheck.Tests.Specs
             return freePort;
         }
 
-        private HttpListener startServer(string host, int port, int statusCode = 200, string content = "Hello!")
+        private HttpListener startHttpServer(string host, int port, int statusCode = 200, string content = "Hello!", TimeSpan? wait = null)
         {
             var listener = new HttpListener();
             listener.Prefixes.Add(String.Format("http://{0}:{1}/", host, port));
@@ -103,12 +180,17 @@ namespace Healthcheck.Tests.Specs
             {
                 try
                 {
-                    for (;;)
+                    for (; ; )
                     {
                         var httpContext = listener.GetContext();
                         httpContext.Response.StatusCode = statusCode;
                         var resp = UTF8Encoding.UTF8.GetBytes(content);
                         httpContext.Response.OutputStream.Write(resp, 0, resp.Length);
+                        if (wait.HasValue)
+                        {
+                            Thread.Sleep(wait.Value);
+                        }
+
                         httpContext.Response.OutputStream.Close();
                     }
                 }
@@ -119,6 +201,25 @@ namespace Healthcheck.Tests.Specs
             }));
             listenThread.Start();
             return listener;
+        }
+
+        private TcpListener startTcpServer(IPAddress host, int port)
+        {
+            var tcpListener = new TcpListener(host, port);
+            var listenThread = new Thread(new ThreadStart(() =>
+            {
+                try
+                {
+                    tcpListener.Start();
+                    tcpListener.AcceptTcpClient();
+                }
+                catch (Exception)
+                {
+                    // ignore the exception
+                }
+            }));
+            listenThread.Start();
+            return tcpListener;
         }
     }
 }

--- a/Healthcheck/Healthcheck.csproj
+++ b/Healthcheck/Healthcheck.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,19 +38,35 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Healthcheck/Options.cs
+++ b/Healthcheck/Options.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+using CommandLine.Text;
+
+namespace Healthcheck
+{
+    public enum OptionBool
+    {
+        False,
+        True
+    }
+
+    public class Options
+    {
+        [Option("network", Required = false, DefaultValue = "tcp", HelpText = "network type to dial with (only 'tcp' is supported)")]
+        public string Network { get; set; }
+
+        [Option("uri", Required = false, DefaultValue = "")]
+        public string UriSuffix { get; set; }
+
+        [Option("port", Required = false, DefaultValue = 8080)]
+        public int Port { get; set; }
+
+        [Option("timeout", Required = false, DefaultValue = "1s")]
+        public string Timeout { get; set; }
+
+
+        [HelpOption]
+        public string GetUsage()
+        {
+            return HelpText.AutoBuild(this,
+              (HelpText current) => HelpText.DefaultParsingErrorsHandler(this, current));
+        }
+    }
+}

--- a/Healthcheck/Program.cs
+++ b/Healthcheck/Program.cs
@@ -1,72 +1,161 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
-using System.Web.Script.Serialization;
-
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Healthcheck
 {
-    internal class Program
+    class Program
     {
-        private static void Main(string[] args)
+        static void Main(string[] args)
         {
-            var client = new HttpClient();
-            var instancePorts = Environment.GetEnvironmentVariable("CF_INSTANCE_PORTS");
-            if (instancePorts == null)
-                throw new Exception("CF_INSTANCE_PORTS is not defined");
-
-            var internalPort = args[0].Split('=')[1];
-            var externalPort = getExternalPort(instancePorts, internalPort);
-            if (externalPort == "")
+            SanitizeArgs(args);
+            var options = new Options();
+            if (!CommandLine.Parser.Default.ParseArguments(args, options))
             {
-                Console.WriteLine("healthcheck failed, port mapping not found for " + internalPort + " in " +
-                                  instancePorts);
                 Environment.Exit(1);
             }
 
+            Run(options);
+        }
+
+        private static void Run(Options options)
+        {
+            var jsonInstancePorts = Environment.GetEnvironmentVariable("CF_INSTANCE_PORTS");
+            if (jsonInstancePorts == null)
+            {
+                throw new Exception("CF_INSTANCE_PORTS is not defined");
+            }
+
+            var externalPort = getExternalPort(jsonInstancePorts, options.Port);
+            if (externalPort == 0)
+            {
+                Console.WriteLine("healthcheck failed, port mapping not found for " + options.Port.ToString() + " in " + jsonInstancePorts);
+                Environment.Exit(1);
+            }
+
+            if (options.Network != "tcp")
+            {
+                Console.WriteLine("healthcheck failed, network type '{0}' not supported", options.Network);
+            }
+
+            int port = externalPort;
+            TimeSpan timeout = ParseTimeoutFromArgs(options.Timeout);
+
+            var instanceIp = Environment.GetEnvironmentVariable("CF_INSTANCE_IP");
+
+
+            if (options.UriSuffix.Length > 0)
+            {
+                httpHealthCheck(instanceIp, port, options.UriSuffix, timeout);
+            }
+            else
+            {
+                tcpHealthCheck(instanceIp, port, timeout);
+            }
+
+            System.Console.WriteLine("healthcheck failed");
+            System.Environment.Exit(1);
+        }
+
+        private static void tcpHealthCheck(string address, int port, TimeSpan timeout)
+        {
             try
             {
-                var task =
-                    client.GetAsync(String.Format("http://{0}:{1}", Environment.GetEnvironmentVariable("CF_INSTANCE_IP"), externalPort));
-                if (task.Wait(1000))
+                using (var tcpClient = new TcpClient())
                 {
-                    if (task.Result.IsSuccessStatusCode)
+                    IAsyncResult connectResult = tcpClient.BeginConnect(address, port, null, null);
+                    if (!connectResult.AsyncWaitHandle.WaitOne(timeout, false))
                     {
+                        tcpClient.EndConnect(connectResult);
+                        return;
+                    }
+
+                    if (tcpClient.Connected)
+                    {
+                        tcpClient.Close();
+
                         Console.WriteLine("healthcheck passed");
                         Environment.Exit(0);
                     }
-                    else
-                    {
-                        Console.Error.WriteLine("Got error response: " +
-                                          task.Result.Content.ReadAsStringAsync().Result);
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("waiting for process to start up");
                 }
             }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.ToString());
-            }
-
-            Console.WriteLine("healthcheck failed");
-
-            Environment.Exit(1);
+            catch { }
         }
 
-        private static string getExternalPort(string jsonInstancePorts, string internalPort)
+        private static void httpHealthCheck(string address, int port, string uriSuffix, TimeSpan timeout)
         {
-            var serializer = new JavaScriptSerializer();
-            var instancePorts = serializer.Deserialize<List<Dictionary<string, string>>>(jsonInstancePorts);
+            try
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    var task = httpClient.GetAsync(String.Format("http://{0}:{1}{2}", address, port, uriSuffix));
+                    if (task.Wait(timeout))
+                    {
+                        if (task.Result.IsSuccessStatusCode)
+                        {
+                            Console.WriteLine("healthcheck passed");
+                            Environment.Exit(0);
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine("Got error response: " + task.Result.Content.ReadAsStringAsync().Result);
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("waiting for process to start up");
+                    }
+
+                }
+            }
+            catch { }
+        }
+
+        private static void SanitizeArgs(string[] args)
+        {
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i].StartsWith("-") && !args[i].StartsWith("--"))
+                {
+                    args[i] = "-" + args[i];
+                }
+            }
+        }
+
+        private static int getExternalPort(string jsonInstancePorts, int internalPort)
+        {
+            var instancePorts = JsonConvert.DeserializeObject<List<Dictionary<string, int>>>(jsonInstancePorts);
             var match = instancePorts.FirstOrDefault(x => x["internal"] == internalPort);
             if (match == null)
             {
-                return "";
+                return 0;
             }
             return match["external"];
+        }
+
+        private static TimeSpan ParseTimeoutFromArgs(string timeout)
+        {
+            if (timeout.EndsWith("ms"))
+            {
+                var milliseconds = int.Parse(timeout.Substring(0, timeout.Length - 2));
+                return TimeSpan.FromMilliseconds(milliseconds);
+            }
+
+            if (timeout.EndsWith("s"))
+            {
+                var seconds = int.Parse(timeout.Substring(0, timeout.Length - 1));
+                return TimeSpan.FromSeconds(seconds);
+            }
+
+            throw new ArgumentException(String.Format("Unable to parse duration: '{0}'", timeout), "timeout");
         }
     }
 }

--- a/Healthcheck/packages.config
+++ b/Healthcheck/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
It can also check for HTTP health if the 'uri' arg
is given. This mimics the behavior of the healthcheck
for Linux.

Also, change the json parser in healthcheck from JavaScriptSerializer
to Json.NET library as recommended by Msdn docs.

A reason behind this change is that some web apps will not return successfully when hitting the root endpoint.

A reason behind this change is that some web apps will not return successfully when hitting the root endpoint.
